### PR TITLE
fix: logger debug flag not being set Due to the order package init functions are called, the logger debug flag was not set when the debug flas was passed to the cli.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,8 +21,11 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"go.uber.org/zap"
 
 	"github.com/alex1989hu/kubelet-serving-cert-approver/build"
+	"github.com/alex1989hu/kubelet-serving-cert-approver/controller/certificatesigningrequest"
+	"github.com/alex1989hu/kubelet-serving-cert-approver/logger"
 )
 
 const defaultNamespace = "kubelet-serving-cert-approver"
@@ -73,6 +76,10 @@ func init() {
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		log.Fatalf("Can not bind flags: %v", err)
 	}
+
+	certificatesigningrequest.SetLogger(
+		logger.CreateLogger().With(zap.String("controller", "certificatesigningrequest")),
+	)
 }
 
 // initConfig reads environment variables if set.

--- a/controller/certificatesigningrequest/certificatesigningrequest.go
+++ b/controller/certificatesigningrequest/certificatesigningrequest.go
@@ -23,3 +23,8 @@ import (
 
 //nolint:gochecknoglobals
 var log = logger.CreateLogger().With(zap.String("controller", "certificatesigningrequest"))
+
+// SetLogger sets the package logger
+func SetLogger(logger *zap.Logger) {
+	log = logger
+}


### PR DESCRIPTION
CLI debug flag was not respected by the logger.

As submodules are initialized before modules, the viper debug bool was not set
at the time the logger was created. 

Signed-off-by: Davincible <david.brouwer.99@gmail.com>
