### PR TITLE
feat: reduce memory usage

### DIFF
--- a/controller/certificatesigningrequest/controller.go
+++ b/controller/certificatesigningrequest/controller.go
@@ -30,6 +30,7 @@ import (
 	k8sclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/alex1989hu/kubelet-serving-cert-approver/metrics"
@@ -205,8 +206,9 @@ func (r *SigningReconciler) authorize(csr *certificatesv1.CertificateSigningRequ
 // SetupWithManager configures controller for manager to handle CertificateSigningRequest.
 func (r *SigningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr). //nolint:wrapcheck
-							For(&certificatesv1.CertificateSigningRequest{}).
-							Complete(r)
+		// watch PartialObjectMetadata to reduce memory consumption
+		For(&certificatesv1.CertificateSigningRequest{}, builder.OnlyMetadata).
+		Complete(r)
 }
 
 // appendApprovalCondition sets fields for audit purpose.


### PR DESCRIPTION
I've noticed the memory usage of this controller balloon during scale-ups (when many nodes join the cluster in a short period). In my case (using `kubeadm`) multiple CSRs are created for each node, so the number of CSRs can become quite large.

This PR reduces memory usage in two ways:
1. We watch `PartialObjectMetadata` for CSRs instead of the full CSR object. This makes the watch channel cheaper for the controller and the apiserver, and means the `client-go` informer cache is minimal. This is acceptable because we always fetch the current CSR from the apiserver. (~45% reduction).
2. We trim `ManagedFields` from the `PartialObjectMetadata`, which is not needed and is quite verbose. (~10% reduction).

This reduces memory usage by ~50-55% in my environment, with no change in behavior. The example below does not include change 2, so you can still see the impact of `ManagedFields`.

Before:
<img width="1672" height="318" alt="Screenshot 2026-01-14 at 12 24 49 PM" src="https://github.com/user-attachments/assets/840dbd1f-a9c8-458a-9fed-31d5c7c35bf3" />

After:

<img width="1676" height="541" alt="Screenshot 2026-01-14 at 12 24 33 PM" src="https://github.com/user-attachments/assets/7e159c1e-c0b1-4c1d-badc-5b19714d51b4" />
